### PR TITLE
Corrected "Forward" translation in context of web browser

### DIFF
--- a/res/values-sk/strings.xml
+++ b/res/values-sk/strings.xml
@@ -64,7 +64,7 @@
     <string name="stop" msgid="5687251076030630074">"Zastaviť"</string>
     <string name="reload" msgid="8585220783228408062">"Obnoviť"</string>
     <string name="back" msgid="8414603107175713668">"Späť"</string>
-    <string name="forward" msgid="4288210890526641577">"Poslať ďalej"</string>
+    <string name="forward" msgid="4288210890526641577">"Dopredu"</string>
     <string name="save" msgid="5922311934992468496">"OK"</string>
     <string name="do_not_save" msgid="6777633870113477714">"Zrušiť"</string>
     <string name="location" msgid="969988560160364559">"Poloha"</string>


### PR DESCRIPTION
Previously was in context of forwarding an email.
