### PR TITLE
Add DuckDuckGo to all locales

### DIFF
--- a/res/values-cs-rCZ/donottranslate-search_engines.xml
+++ b/res/values-cs-rCZ/donottranslate-search_engines.xml
@@ -27,5 +27,6 @@ Each value in the string-array is the name of a value in all_search_engines.xml
     <item>bing_cs_CZ</item>
     <item>centrum_cz</item>
     <item>atlas_cz</item>
+    <item>duckduckgo</item>
   </string-array>
 </resources>

--- a/res/values-da-rDK/donottranslate-search_engines.xml
+++ b/res/values-da-rDK/donottranslate-search_engines.xml
@@ -25,5 +25,6 @@ Each value in the string-array is the name of a value in all_search_engines.xml
     <item>google</item>
     <item>bing_da_DK</item>
     <item>yahoo_dk</item>
+    <item>duckduckgo</item>
   </string-array>
 </resources>

--- a/res/values-de-rAT/donottranslate-search_engines.xml
+++ b/res/values-de-rAT/donottranslate-search_engines.xml
@@ -25,5 +25,6 @@ Each value in the string-array is the name of a value in all_search_engines.xml
     <item>google</item>
     <item>yahoo_at</item>
     <item>bing_de_AT</item>
+    <item>duckduckgo</item>
   </string-array>
 </resources>

--- a/res/values-de-rCH/donottranslate-search_engines.xml
+++ b/res/values-de-rCH/donottranslate-search_engines.xml
@@ -28,5 +28,6 @@ Each value in the string-array is the name of a value in all_search_engines.xml
     <item>bing_fr_CH</item>
     <item>search_de_CH</item>
     <item>search_fr_CH</item>
+    <item>duckduckgo</item>
   </string-array>
 </resources>

--- a/res/values-de-rDE/donottranslate-search_engines.xml
+++ b/res/values-de-rDE/donottranslate-search_engines.xml
@@ -26,5 +26,6 @@ Each value in the string-array is the name of a value in all_search_engines.xml
     <item>ask_de</item>
     <item>bing_de_DE</item>
     <item>yahoo_de</item>
+    <item>duckduckgo</item>
   </string-array>
 </resources>

--- a/res/values-el-rGR/donottranslate-search_engines.xml
+++ b/res/values-el-rGR/donottranslate-search_engines.xml
@@ -26,5 +26,6 @@ Each value in the string-array is the name of a value in all_search_engines.xml
     <item>yahoo</item>
     <item>in</item>
     <item>bing_el_GR</item>
+    <item>duckduckgo</item>
   </string-array>
 </resources>

--- a/res/values-en-rAU/donottranslate-search_engines.xml
+++ b/res/values-en-rAU/donottranslate-search_engines.xml
@@ -25,5 +25,6 @@ Each value in the string-array is the name of a value in all_search_engines.xml
     <item>google</item>
     <item>bing_en_AU</item>
     <item>yahoo_au</item>
+    <item>duckduckgo</item>
   </string-array>
 </resources>

--- a/res/values-en-rIE/donottranslate-search_engines.xml
+++ b/res/values-en-rIE/donottranslate-search_engines.xml
@@ -25,5 +25,6 @@ Each value in the string-array is the name of a value in all_search_engines.xml
     <item>google</item>
     <item>yahoo_uk</item>
     <item>bing_en_IE</item>
+    <item>duckduckgo</item>
   </string-array>
 </resources>

--- a/res/values-en-rNZ/donottranslate-search_engines.xml
+++ b/res/values-en-rNZ/donottranslate-search_engines.xml
@@ -25,5 +25,6 @@ Each value in the string-array is the name of a value in all_search_engines.xml
     <item>google</item>
     <item>yahoo_nz</item>
     <item>bing_en_NZ</item>
+    <item>duckduckgo</item>
   </string-array>
 </resources>

--- a/res/values-en-rSG/donottranslate-search_engines.xml
+++ b/res/values-en-rSG/donottranslate-search_engines.xml
@@ -26,5 +26,6 @@ Each value in the string-array is the name of a value in all_search_engines.xml
     <item>yahoo_sg</item>
     <item>bing_en_SG</item>
     <item>rednano</item>
+    <item>duckduckgo</item>
   </string-array>
 </resources>

--- a/res/values-en-rZA/donottranslate-search_engines.xml
+++ b/res/values-en-rZA/donottranslate-search_engines.xml
@@ -25,5 +25,6 @@ Each value in the string-array is the name of a value in all_search_engines.xml
     <item>google</item>
     <item>yahoo</item>
     <item>bing_en_ZA</item>
+    <item>duckduckgo</item>
   </string-array>
 </resources>

--- a/res/values-es-rES/donottranslate-search_engines.xml
+++ b/res/values-es-rES/donottranslate-search_engines.xml
@@ -28,5 +28,6 @@ Each value in the string-array is the name of a value in all_search_engines.xml
     <item>yahoo_es</item>
     <item>terra_es</item>
     <item>hispavista</item>
+    <item>duckduckgo</item>
   </string-array>
 </resources>

--- a/res/values-fr-rBE/donottranslate-search_engines.xml
+++ b/res/values-fr-rBE/donottranslate-search_engines.xml
@@ -26,5 +26,6 @@ Each value in the string-array is the name of a value in all_search_engines.xml
     <item>bing_nl_BE</item>
     <item>yahoo</item>
     <item>bing_fr_BE</item>
+    <item>duckduckgo</item>
   </string-array>
 </resources>

--- a/res/values-fr-rFR/donottranslate-search_engines.xml
+++ b/res/values-fr-rFR/donottranslate-search_engines.xml
@@ -25,5 +25,6 @@ Each value in the string-array is the name of a value in all_search_engines.xml
     <item>google</item>
     <item>yahoo_fr</item>
     <item>bing_fr_FR</item>
+    <item>duckduckgo</item>
   </string-array>
 </resources>

--- a/res/values-it-rIT/donottranslate-search_engines.xml
+++ b/res/values-it-rIT/donottranslate-search_engines.xml
@@ -28,5 +28,6 @@ Each value in the string-array is the name of a value in all_search_engines.xml
     <item>bing_it_IT</item>
     <item>yahoo_it</item>
     <item>libero</item>
+    <item>duckduckgo</item>
   </string-array>
 </resources>

--- a/res/values-ja-rJP/donottranslate-search_engines.xml
+++ b/res/values-ja-rJP/donottranslate-search_engines.xml
@@ -26,5 +26,6 @@ Each value in the string-array is the name of a value in all_search_engines.xml
     <item>yahoo_jp</item>
     <item>bing_ja_JP</item>
     <item>goo</item>
+    <item>duckduckgo</item>
   </string-array>
 </resources>

--- a/res/values-ko-rKR/donottranslate-search_engines.xml
+++ b/res/values-ko-rKR/donottranslate-search_engines.xml
@@ -27,5 +27,6 @@ Each value in the string-array is the name of a value in all_search_engines.xml
     <item>daum</item>
     <item>yahoo_kr</item>
     <item>nate</item>
+    <item>duckduckgo</item>
   </string-array>
 </resources>

--- a/res/values-nb-rNO/donottranslate-search_engines.xml
+++ b/res/values-nb-rNO/donottranslate-search_engines.xml
@@ -27,5 +27,6 @@ Each value in the string-array is the name of a value in all_search_engines.xml
     <item>abcsok</item>
     <item>yahoo_no</item>
     <item>kvasir</item>
+    <item>duckduckgo</item>
   </string-array>
 </resources>

--- a/res/values-nl-rBE/donottranslate-search_engines.xml
+++ b/res/values-nl-rBE/donottranslate-search_engines.xml
@@ -26,5 +26,6 @@ Each value in the string-array is the name of a value in all_search_engines.xml
     <item>bing_nl_BE</item>
     <item>yahoo</item>
     <item>bing_fr_BE</item>
+    <item>duckduckgo</item>
   </string-array>
 </resources>

--- a/res/values-nl-rNL/donottranslate-search_engines.xml
+++ b/res/values-nl-rNL/donottranslate-search_engines.xml
@@ -26,5 +26,6 @@ Each value in the string-array is the name of a value in all_search_engines.xml
     <item>bing_nl_NL</item>
     <item>yahoo_nl</item>
     <item>ask_nl</item>
+    <item>duckduckgo</item>
   </string-array>
 </resources>

--- a/res/values-pl-rPL/donottranslate-search_engines.xml
+++ b/res/values-pl-rPL/donottranslate-search_engines.xml
@@ -28,5 +28,6 @@ Each value in the string-array is the name of a value in all_search_engines.xml
     <item>yahoo_uk</item>
     <item>onet</item>
     <item>wp</item>
+    <item>duckduckgo</item>
   </string-array>
 </resources>

--- a/res/values-pt-rBR/donottranslate-search_engines.xml
+++ b/res/values-pt-rBR/donottranslate-search_engines.xml
@@ -26,5 +26,6 @@ Each value in the string-array is the name of a value in all_search_engines.xml
     <item>bing_pt_BR</item>
     <item>yahoo_br</item>
     <item>uol</item>
+    <item>duckduckgo</item>
   </string-array>
 </resources>

--- a/res/values-pt-rPT/donottranslate-search_engines.xml
+++ b/res/values-pt-rPT/donottranslate-search_engines.xml
@@ -26,5 +26,6 @@ Each value in the string-array is the name of a value in all_search_engines.xml
     <item>sapo</item>
     <item>bing_pt_PT</item>
     <item>yahoo</item>
+    <item>duckduckgo</item>
   </string-array>
 </resources>

--- a/res/values-sv-rSE/donottranslate-search_engines.xml
+++ b/res/values-sv-rSE/donottranslate-search_engines.xml
@@ -28,5 +28,6 @@ Each value in the string-array is the name of a value in all_search_engines.xml
     <item>altavista_se</item>
     <item>spray</item>
     <item>eniro_se</item>
+    <item>duckduckgo</item>
   </string-array>
 </resources>

--- a/res/values-tr-rTR/donottranslate-search_engines.xml
+++ b/res/values-tr-rTR/donottranslate-search_engines.xml
@@ -26,5 +26,6 @@ Each value in the string-array is the name of a value in all_search_engines.xml
     <item>bing_tr_TR</item>
     <item>yahoo</item>
     <item>mynet</item>
+    <item>duckduckgo</item>
   </string-array>
 </resources>

--- a/res/values-zh-rCN/donottranslate-search_engines.xml
+++ b/res/values-zh-rCN/donottranslate-search_engines.xml
@@ -26,5 +26,6 @@ Each value in the string-array is the name of a value in all_search_engines.xml
     <item>baidu</item>
     <item>yahoo_cn</item>
     <item>bing_zh_CN</item>
+    <item>duckduckgo</item>
   </string-array>
 </resources>

--- a/res/values-zh-rHK/donottranslate-search_engines.xml
+++ b/res/values-zh-rHK/donottranslate-search_engines.xml
@@ -26,5 +26,6 @@ Each value in the string-array is the name of a value in all_search_engines.xml
     <item>yahoo_hk</item>
     <item>bing_zh_HK</item>
     <item>baidu</item>
+    <item>duckduckgo</item>
   </string-array>
 </resources>

--- a/res/values-zh-rTW/donottranslate-search_engines.xml
+++ b/res/values-zh-rTW/donottranslate-search_engines.xml
@@ -25,5 +25,6 @@ Each value in the string-array is the name of a value in all_search_engines.xml
     <item>google</item>
     <item>yahoo_tw</item>
     <item>bing_zh_TW</item>
+    <item>duckduckgo</item>
   </string-array>
 </resources>


### PR DESCRIPTION
This is the default search. More specific entries could be added for
each country, similar to duckduckgo_en_gb in
res/values/all_search_engines.xml.

Signed-off-by: Olivier Mehani shtrom@ssji.net
